### PR TITLE
ENH: Add two-pass mean-variance and covariance gufuncs.

### DIFF
--- a/src/meanvar/define_cxx_gufunc_extmod.py
+++ b/src/meanvar/define_cxx_gufunc_extmod.py
@@ -84,8 +84,52 @@ ufunc = UFunc(
     nonzero_coredims=['n'],  # n must be at least 1.
 )
 
+meanvar_2pass_ufunc_src = UFuncSource(
+    funcname='meanvar_twopass_core',
+    typesignatures=int_type_sigs + float_type_sigs,
+)
+
+meanvar_2pass_ufunc = UFunc(
+    name='meanvar_twopass',
+    header='meanvar_gufunc.h',
+    docstring=MEANVAR_DOCSTRING,
+    signature='(n),()->(2)',
+    sources=[meanvar_2pass_ufunc_src],
+    nonzero_coredims=['n'],
+)
+
+cov_ufunc_src = UFuncSource(
+    funcname='covariance_matrix_core',
+    typesignatures=int_type_sigs + float_type_sigs,
+)
+
+cov_ufunc = UFunc(
+    name='covariance_matrix',
+    header='meanvar_gufunc.h',
+    docstring='''covariance_matrix(arr, ddof, /, ...)
+
+    Calculate the covariance matrix of the n_samples by n_features array.
+
+    Parameters
+    ----------
+    arr : array_like
+        The n_samples by n_features array
+        NB: This is the reverse of the np.cov convention
+    ddof : int
+        The degrees of freedom for the denominator in the covariance
+        calculation.
+
+    Returns
+    -------
+    out : ndarray
+    ''',
+    signature='(n,m),()->(m,m)',
+    sources=[cov_ufunc_src],
+    process_core_dims_func="preprocess_cov_core_dims",
+)
+
 extmod = UFuncExtMod(
     module='_meanvar',
     docstring="This extension module defines the gufunc 'meanvar'.",
-    ufuncs=[ufunc],
+    ufuncs=[ufunc, meanvar_2pass_ufunc, cov_ufunc],
 )

--- a/src/meanvar/meanvar_gufunc.h
+++ b/src/meanvar/meanvar_gufunc.h
@@ -47,4 +47,96 @@ static void meanvar_core(
     set(p_out, out_stride, 1, var);
 }
 
+template<typename T, typename U>
+static void meanvar_twopass_core(
+        npy_intp n,           // core dimension n
+        const T * const p_x,               // pointer to first element of x, a strided 1-d array with n elements
+        npy_intp x_stride,    // stride (in bytes) for elements of x
+        const npy_intp * const p_ddof,     // pointer to ddof
+        U *p_out,             // pointer to first element of out, a strided 1-d array with 2 elements
+        npy_intp out_stride   // stride (in bytes) for elements of out
+)
+{
+    U mean = 0.0;
+    U var = 0.0, tmp;
+    for (npy_intp k = 0; k < n; ++k) {
+        T xk = get(p_x, x_stride, k);
+	mean += xk;
+    }
+    mean /= n;
+    for (npy_intp k = 0; k < n; ++k) {
+      T xk = get(p_x, x_stride, k);
+      tmp = xk - mean;
+      var += tmp * tmp;
+    }
+    var /= (n - *p_ddof);
+    *p_out = mean;
+    set(p_out, out_stride, 1, var);
+}
+
+template<typename T, typename U>
+static void covariance_matrix_core(
+				   npy_intp n,
+				   npy_intp m,
+				   const T * const p_x,
+				   const npy_intp x_strides[2],
+				   const npy_intp * const p_ddof,
+				   U *p_out,
+				   const npy_intp out_strides[2]
+				   )
+{
+  U mean[m] = {0.0};
+  U cov[m*m] = {0.0};
+  U tmp1, tmp2;
+  for (npy_intp i = 0; i < n; ++i) {
+    #pragma GCC ivdep
+    for (npy_intp j = 0; j < m; ++j) {
+      T x_ij = get2d(p_x, x_strides, i, j);
+      mean[j] += x_ij;
+    }
+  }
+  for (npy_intp j = 0; j < m; ++j) {
+    mean[j] /= n;
+  }
+  for (npy_intp i = 0; i < n; ++i) {
+    #pragma GCC ivdep
+    for (npy_intp j = 0; j < m; ++j) {
+      T x_ij = get2d(p_x, x_strides, i, j);
+      tmp1 = x_ij - mean[j];
+      #pragma GCC ivdep
+      for (npy_intp k = j; k < m; ++k) {
+	T x_ik = get2d(p_x, x_strides, i, k);
+	tmp2 = x_ik - mean[k];
+	cov[j * m + k] += tmp1 * tmp2;
+      }
+    }
+  }
+  for (npy_intp j = 0; j < m; ++j) {
+    for (npy_intp k = j; k < m; ++k) {
+      tmp1 = cov[j * m + k] / (n - *p_ddof);
+      set2d(p_out, out_strides, j, k, tmp1);
+      set2d(p_out, out_strides, k, j, tmp1);
+    }
+  }
+}
+
+extern "C" {
+  static int
+  preprocess_cov_core_dims(PyUFuncObject *ufunc, npy_intp *core_dim_sizes) {
+    npy_intp n = core_dim_sizes[0];
+    npy_intp m = core_dim_sizes[1];
+    if (n < 2) {
+      PyErr_SetString(PyExc_ValueError,
+		      "covariance_matrix requires at least two samples");
+      return -1;
+    }
+    if (m < 1) {
+      PyErr_SetString(PyExc_ValueError,
+		      "covariance_matrix requires at least one feature");
+      return -1;
+    }
+    return 0;
+  }
+}
+
 #endif  // UFUNCLAB_MEANVAR_GUFUNC_H

--- a/src/meanvar/meanvar_gufunc.h
+++ b/src/meanvar/meanvar_gufunc.h
@@ -23,6 +23,51 @@ compensated_update(U val, U incr, U comp)
     return std::make_pair(t, c);
 }
 
+template <typename Real, size_t N_accumulators=10>
+class pairwise_accumulator {
+private:
+  Real accumulators[N_accumulators] = {0};
+  std::size_t n_elements = 0, accum_index = 0;
+
+public:
+  inline void reset() {
+    for (size_t i = 0; i < N_accumulators; ++i) {
+      accumulators[i] = 0;
+    }
+    n_elements = 0;
+    accum_index = 0;
+  }
+
+  inline void add_data(Real num) {
+    ++n_elements;
+    accumulators[accum_index] += num;
+    for (std::size_t tst = 1;
+	 tst < n_elements && (n_elements & tst) == 0 && accum_index > 0;
+	 tst <<= 1, --accum_index) {
+      accumulators[accum_index - 1] += accumulators[accum_index];
+      accumulators[accum_index] = 0;
+    }
+    ++accum_index;
+    if (accum_index == N_accumulators) {
+      Real tmp = 0;
+      for (size_t i = N_accumulators - 1; i > 0; --i) {
+	tmp += accumulators[i];
+	accumulators[i] = 0;
+      }
+      accumulators[0] += tmp;
+      accum_index = 1;
+    }
+  }
+
+  constexpr inline Real get_sum() {
+    Real result = 0;
+    for (long i = N_accumulators - 1; i >= 0; --i) {
+      result += accumulators[i];
+    }
+    return result;
+  }
+};
+
 template<typename T, typename U>
 static void meanvar_core(
         npy_intp n,           // core dimension n
@@ -50,26 +95,28 @@ static void meanvar_core(
 template<typename T, typename U>
 static void meanvar_twopass_core(
         npy_intp n,           // core dimension n
-        const T * const p_x,               // pointer to first element of x, a strided 1-d array with n elements
+        const T * const p_x,          // pointer to first element of x, a strided 1-d array with n elements
         npy_intp x_stride,    // stride (in bytes) for elements of x
-        const npy_intp * const p_ddof,     // pointer to ddof
+        const npy_intp * const p_ddof,   // pointer to ddof
         U *p_out,             // pointer to first element of out, a strided 1-d array with 2 elements
         npy_intp out_stride   // stride (in bytes) for elements of out
 )
 {
+  pairwise_accumulator<U, 10> accumulator;
     U mean = 0.0;
     U var = 0.0, tmp;
     for (npy_intp k = 0; k < n; ++k) {
-        T xk = get(p_x, x_stride, k);
-	mean += xk;
+      T xk = get(p_x, x_stride, k);
+      accumulator.add_data(xk);
     }
-    mean /= n;
+    mean = accumulator.get_sum() / n;
+    accumulator.reset();
     for (npy_intp k = 0; k < n; ++k) {
       T xk = get(p_x, x_stride, k);
       tmp = xk - mean;
-      var += tmp * tmp;
+      accumulator.add_data(tmp * tmp);
     }
-    var /= (n - *p_ddof);
+    var = accumulator.get_sum() / (n - *p_ddof);
     *p_out = mean;
     set(p_out, out_stride, 1, var);
 }
@@ -86,17 +133,17 @@ static void covariance_matrix_core(
 				   )
 {
   U mean[m] = {0.0};
-  U cov[m*m] = {0.0};
+  pairwise_accumulator<U, 10> mean_accum[m], cov_accum[m*m];
   U tmp1, tmp2;
   for (npy_intp i = 0; i < n; ++i) {
     #pragma GCC ivdep
     for (npy_intp j = 0; j < m; ++j) {
       T x_ij = get2d(p_x, x_strides, i, j);
-      mean[j] += x_ij;
+      mean_accum[j].add_data(x_ij);
     }
   }
   for (npy_intp j = 0; j < m; ++j) {
-    mean[j] /= n;
+    mean[j] = mean_accum[j].get_sum() / n;
   }
   for (npy_intp i = 0; i < n; ++i) {
     #pragma GCC ivdep
@@ -107,13 +154,13 @@ static void covariance_matrix_core(
       for (npy_intp k = j; k < m; ++k) {
 	T x_ik = get2d(p_x, x_strides, i, k);
 	tmp2 = x_ik - mean[k];
-	cov[j * m + k] += tmp1 * tmp2;
+	cov_accum[j * m + k].add_data(tmp1 * tmp2);
       }
     }
   }
   for (npy_intp j = 0; j < m; ++j) {
     for (npy_intp k = j; k < m; ++k) {
-      tmp1 = cov[j * m + k] / (n - *p_ddof);
+      tmp1 = cov_accum[j * m + k].get_sum() / (n - *p_ddof);
       set2d(p_out, out_strides, j, k, tmp1);
       set2d(p_out, out_strides, k, j, tmp1);
     }

--- a/ufunclab/__init__.py
+++ b/ufunclab/__init__.py
@@ -69,6 +69,8 @@ _name_to_module = {
     'pmean': '._means',
     'pmeanw': '._means',
     'meanvar': '._meanvar',
+    'meanvar_twopass': '._meanvar',
+    'covariance_matrix': '._meanvar',
     'kbnsum': '._kbnsum',
     'pearson_corr': '._corr',
     'wjaccard': '._wjaccard',


### PR DESCRIPTION
I could switch these over to an iterative variant of pairwise summation. I could also look into returning the mean from the covariance function as well.

Inspired by discussion on numpy/numpy#13199:
NumPy tries to stay low-level, so statistical functions should go elsewhere. 
Found through numpy/numpy#31292

These may well be out-of-scope for this package.
It might be worth spinning the GUFunc-wrapper generator script into its own package if this commit would work best standalone.